### PR TITLE
Added unwrapAll tokens job for buyback

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ serverless invoke local --function splitRevenue
 - `lowWater` - This function will call rebalance if a maker strategy is lowWater.
 - `feeTransfer` - This function will sweep erc20 tokens (vtokens) from strategies.
 - `updateOracles` - This function will update oracles.
+- `buybackUnwrap` - Unwrap vTokens to native tokens for buyback.
 
 
 #### V2 Pools Functions

--- a/config/default.json
+++ b/config/default.json
@@ -101,6 +101,7 @@
     },
     "revenueConfig": {
       "address": "0xAdB5ef0CA9029b340bCCDEf005aef442C7F91C96",
+      "buybackAddress": "0x9bcdf1130b20856f86267074de136c5902e314fe",
       "payeeCount": 2,
       "parties": ["0xbA4cFE5741b357FA371b506e5db0774aBFeCf8Fc"],
       "tokens": [

--- a/src/abi/buybackUnwrap.json
+++ b/src/abi/buybackUnwrap.json
@@ -1,0 +1,470 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_governor",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_weth",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IVesperPool",
+        "name": "_vVSP",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IAddressListFactory",
+        "name": "_listFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ISwapManager",
+        "name": "_swapManager",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "MigratedAsset",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousGovernor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "proposedGovernor",
+        "type": "address"
+      }
+    ],
+    "name": "UpdatedGovernor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldPeriod",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newPeriod",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldRouterIdx",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newRouterIdx",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdatedOracleConfig",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldSwapManager",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newSwapManager",
+        "type": "address"
+      }
+    ],
+    "name": "UpdatedSwapManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldSwapSlippage",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newSwapSlippage",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdatedSwapSlippage",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptGovernorship",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addressToAdd",
+        "type": "address"
+      }
+    ],
+    "name": "addInKeepersList",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "calls",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "revertOnFail",
+        "type": "bool"
+      }
+    ],
+    "name": "batch",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVesperPool",
+        "name": "_vPool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "depositAndUnwrap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_unwrapped",
+        "type": "address"
+      }
+    ],
+    "name": "doInfinityApproval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "governor",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "keepers",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_assets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      }
+    ],
+    "name": "migrateAssets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oraclePeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracleRouterIdx",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addressToRemove",
+        "type": "address"
+      }
+    ],
+    "name": "removeFromKeepersList",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapForVspAndTransferToVVSP",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "swapManager",
+    "outputs": [
+      {
+        "internalType": "contract ISwapManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "swapSlippage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "transferAllVspToVVSP",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_proposedGovernor",
+        "type": "address"
+      }
+    ],
+    "name": "transferGovernorship",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferVspToVVSP",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVesperPool",
+        "name": "_vPool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "unwrap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVesperPool",
+        "name": "_vPool",
+        "type": "address"
+      }
+    ],
+    "name": "unwrapAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newPeriod",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_newRouterIdx",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateOracleConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_swapManager",
+        "type": "address"
+      }
+    ],
+    "name": "updateSwapManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newSwapSlippage",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateSwapSlippage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vVSP",
+    "outputs": [
+      {
+        "internalType": "contract IVesperPool",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vsp",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/controller/.routes.yml
+++ b/src/controller/.routes.yml
@@ -149,6 +149,12 @@ splitRevenue:
     - http:
         path: /splitRevenue
         method: get
+        
+buybackUnwrap:
+  handler: src/controller/pool.buybackUnwrap
+  timeout: 900
+  events:
+    - schedule: cron(30 18 ? * 1 *)
 
 # feeTransfer:
 #   handler: src/controller/pool.feeTransfer

--- a/src/controller/pool.js
+++ b/src/controller/pool.js
@@ -9,6 +9,7 @@ const lowWater = require('../service/ops/lowWater')
 const rebalance = require('../service/ops/rebalance')
 const resurface = require('../service/ops/resurface')
 const splitRevenue = require('../service/ops/splitRevenue')
+const buybackUnwrap = require('../service/ops/buybackUnwrap')
 const claimComp = require('../service/ops/claimComp')
 const feeTransfer = require('../service/ops/feeTransfer')
 const accrueInterest = require('../service/ops/accrueInterest')
@@ -28,6 +29,7 @@ async function execute(input) {
     rebalance,
     resurface,
     splitRevenue,
+    buybackUnwrap,
     claimComp,
     feeTransfer,
     accrueInterest,
@@ -90,6 +92,10 @@ module.exports.lowWater = () => {
 
 module.exports.splitRevenue = () => {
   return execute({operation: Operation.SPLIT_REVENUE_ERC20})
+}
+
+module.exports.buybackUnwrap = () => {
+  return execute({operation: Operation.BUYBACK_UNWRAP})
 }
 
 module.exports.claimComp = () => {

--- a/src/enum/operation.js
+++ b/src/enum/operation.js
@@ -11,6 +11,7 @@ const Operation = {
   FEE_TRANSFER: 'feeTransfer',
   ACCRUE_INTEREST: 'accrueInterest',
   LOW_WATER: 'lowWater',
+  BUYBACK_UNWRAP: 'unwrapAll',
 }
 
 module.exports = {

--- a/src/service/ops/buybackUnwrap.js
+++ b/src/service/ops/buybackUnwrap.js
@@ -1,0 +1,108 @@
+/* eslint-disable consistent-return */
+'use strict'
+
+const config = require('config')
+const ethers = require('ethers')
+const {getGasPrice, getWallet} = require('../../ethers/eth')
+const {getPriority} = require('../../enum/priority')
+const {Operation} = require('../../enum/operation')
+const {isRecentTransaction} = require('../recent')
+const revenueConfig = config.get('vesper.revenueConfig')
+const {send} = require('../transaction')
+const buybackUnwrapAbi = require('../../abi/buybackUnwrap.json')
+const vesperERC20TokenAbi = require('../../abi/ERC20Abi.json')
+const {BigNumber: BN} = require('ethers')
+const operation = Operation.BUYBACK_UNWRAP
+
+async function shouldSkipTheJob(data) {
+  if (data.batchTxns.length > 0) {
+    return isRecentTransaction(data)
+  }
+  return true
+}
+
+function run(data) {
+  const priority = config.vesper[data.operation] ? config.vesper[data.operation].priority : config.vesper.priority
+  return getGasPrice(data.blockingTxnGasPrice).then(function (gasPrice) {
+    const params = {
+      pool: data.name || data.pool,
+      fromAddress: data.fromAddress,
+      nonce: data.nonce,
+      priority: getPriority(priority),
+      gasPrice,
+      operation: data.operation,
+      toAddress: data.toAddress,
+      isBlockingTxn: !!data.blockingTxnGasPrice,
+    }
+    const methodArgs = [data.batchTxns, false]
+    return send(params, data.contract, 'batch', methodArgs)
+  })
+}
+
+function prepare() {
+  const data = []
+  return getWallet().then(function (wallet) {
+    const contract = new ethers.Contract(revenueConfig.buybackAddress, buybackUnwrapAbi, wallet)
+    const tokensBalPromises = []
+    for (const token of revenueConfig.tokens) {
+      tokensBalPromises.push(
+        new ethers.Contract(token.address, vesperERC20TokenAbi, wallet.provider).balanceOf(revenueConfig.buybackAddress)
+      )
+    }
+    return Promise.all(tokensBalPromises).then(function (tokenBalances) {
+      const unwrapPromises = []
+      tokenBalances.forEach(function (balance, index) {
+        if (balance.gte(BN.from(revenueConfig.tokens[index].minBalance))) {
+          unwrapPromises.push(contract.populateTransaction.unwrapAll(revenueConfig.tokens[index].address))
+        }
+      })
+      const batchTxns = []
+      return Promise.all(unwrapPromises).then(function (txns) {
+        for (const txn of txns) {
+          batchTxns.push(txn.data)
+        }
+        data.push({
+          operationObj: module.exports,
+          toAddress: revenueConfig.buybackAddress,
+          operation: Operation.BUYBACK_UNWRAP,
+          name: Operation.BUYBACK_UNWRAP,
+          batchTxns,
+          fromAddress: wallet.address,
+          contract,
+        })
+        return data
+      })
+    })
+  })
+}
+
+async function before(data) {
+  return require('./pool').before(data)
+}
+
+async function after(data) {
+  return require('./pool').after(data)
+}
+
+async function error(data, _error) {
+  return require('./pool').error(data, _error)
+}
+
+async function executeJob(_data) {
+  return before(_data).then(function (data) {
+    return run(data)
+      .then(function () {
+        return after(data)
+      })
+      .catch(function (_error) {
+        return error(data, _error)
+      })
+  })
+}
+
+module.exports = {
+  prepare,
+  executeJob,
+  shouldSkipTheJob,
+  operation,
+}

--- a/src/service/ops/pool.js
+++ b/src/service/ops/pool.js
@@ -5,6 +5,7 @@ const rebalanceCollateral = require('./rebalanceCollateral')
 const rebalance = require('./rebalance')
 const resurface = require('./resurface')
 const splitRevenue = require('./splitRevenue')
+const buybackUnwrap = require('./buybackUnwrap')
 const lowWater = require('./lowWater')
 const updateOracles = require('./updateOracles')
 const claimComp = require('../../service/ops/claimComp')
@@ -40,6 +41,7 @@ function getOperationObject(data) {
     rebalance,
     resurface,
     splitRevenue,
+    buybackUnwrap,
     updateOracles,
     claimComp,
     lowWater,


### PR DESCRIPTION
The buyback process is divided into two jobs and this PR fix the part 1.

Fix include.
- `unwrapAll` Run it once a week on Sunday evening.
- Submit one batch txn for all vTokens. We have configurable list of tokens which we want to unWrap with minBalance.
- It will unwrap only those vToken which are present in the list and have balance > min balance
- Not including infinite approval in the batch as it's one time job per vToken and can be done manually.