### PR TITLE
Added VSP buyback using buyback contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ serverless invoke local --function splitRevenue
 - `lowWater` - This function will call rebalance if a maker strategy is lowWater.
 - `feeTransfer` - This function will sweep erc20 tokens (vtokens) from strategies.
 - `updateOracles` - This function will update oracles.
+- `buybackVsp` - Buyback VSP using an asset with provided amount.
 
 
 #### V2 Pools Functions

--- a/config/default.json
+++ b/config/default.json
@@ -101,6 +101,7 @@
     },
     "revenueConfig": {
       "address": "0xAdB5ef0CA9029b340bCCDEf005aef442C7F91C96",
+      "buybackAddress": "0x9bcdf1130b20856f86267074de136c5902e314fe",
       "payeeCount": 2,
       "parties": ["0xbA4cFE5741b357FA371b506e5db0774aBFeCf8Fc"],
       "tokens": [

--- a/src/abi/buybackAbi.json
+++ b/src/abi/buybackAbi.json
@@ -1,0 +1,470 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_governor",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_weth",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IVesperPool",
+        "name": "_vVSP",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IAddressListFactory",
+        "name": "_listFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ISwapManager",
+        "name": "_swapManager",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract IERC20",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "MigratedAsset",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousGovernor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "proposedGovernor",
+        "type": "address"
+      }
+    ],
+    "name": "UpdatedGovernor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldPeriod",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newPeriod",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldRouterIdx",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newRouterIdx",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdatedOracleConfig",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldSwapManager",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newSwapManager",
+        "type": "address"
+      }
+    ],
+    "name": "UpdatedSwapManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldSwapSlippage",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newSwapSlippage",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdatedSwapSlippage",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptGovernorship",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addressToAdd",
+        "type": "address"
+      }
+    ],
+    "name": "addInKeepersList",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "calls",
+        "type": "bytes[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "revertOnFail",
+        "type": "bool"
+      }
+    ],
+    "name": "batch",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVesperPool",
+        "name": "_vPool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "depositAndUnwrap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_unwrapped",
+        "type": "address"
+      }
+    ],
+    "name": "doInfinityApproval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "governor",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "keepers",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_assets",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      }
+    ],
+    "name": "migrateAssets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oraclePeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracleRouterIdx",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_addressToRemove",
+        "type": "address"
+      }
+    ],
+    "name": "removeFromKeepersList",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapForVspAndTransferToVVSP",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "swapManager",
+    "outputs": [
+      {
+        "internalType": "contract ISwapManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "swapSlippage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "transferAllVspToVVSP",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_proposedGovernor",
+        "type": "address"
+      }
+    ],
+    "name": "transferGovernorship",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferVspToVVSP",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVesperPool",
+        "name": "_vPool",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "unwrap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVesperPool",
+        "name": "_vPool",
+        "type": "address"
+      }
+    ],
+    "name": "unwrapAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newPeriod",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_newRouterIdx",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateOracleConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_swapManager",
+        "type": "address"
+      }
+    ],
+    "name": "updateSwapManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newSwapSlippage",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateSwapSlippage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vVSP",
+    "outputs": [
+      {
+        "internalType": "contract IVesperPool",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vsp",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abi/poolProxyImpl.json
+++ b/src/abi/poolProxyImpl.json
@@ -1,5 +1,9 @@
 [
-  {"inputs": [], "stateMutability": "nonpayable", "type": "constructor"},
+  {
+    "inputs": [{"internalType": "address", "name": "_controller", "type": "address"}],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
   {
     "anonymous": false,
     "inputs": [
@@ -18,20 +22,6 @@
       {"indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256"}
     ],
     "name": "Deposit",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {"indexed": true, "internalType": "address", "name": "strategy", "type": "address"},
-      {"indexed": false, "internalType": "uint256", "name": "profit", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "loss", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "payback", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "strategyDebt", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "poolDebt", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "creditLine", "type": "uint256"}
-    ],
-    "name": "EarningReported",
     "type": "event"
   },
   {
@@ -55,29 +45,6 @@
   {
     "anonymous": false,
     "inputs": [
-      {"indexed": true, "internalType": "address", "name": "strategy", "type": "address"},
-      {"indexed": false, "internalType": "uint256", "name": "interestFee", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "debtRatio", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "debtRate", "type": "uint256"}
-    ],
-    "name": "StrategyAdded",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {"indexed": true, "internalType": "address", "name": "oldStrategy", "type": "address"},
-      {"indexed": true, "internalType": "address", "name": "newStrategy", "type": "address"},
-      {"indexed": false, "internalType": "uint256", "name": "interestFee", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "debtRatio", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "debtRate", "type": "uint256"}
-    ],
-    "name": "StrategyMigrated",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
       {"indexed": true, "internalType": "address", "name": "from", "type": "address"},
       {"indexed": true, "internalType": "address", "name": "to", "type": "address"},
       {"indexed": false, "internalType": "uint256", "name": "value", "type": "uint256"}
@@ -94,52 +61,6 @@
   {
     "anonymous": false,
     "inputs": [
-      {"indexed": true, "internalType": "address", "name": "previousFeeCollector", "type": "address"},
-      {"indexed": true, "internalType": "address", "name": "newFeeCollector", "type": "address"}
-    ],
-    "name": "UpdatedFeeCollector",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {"indexed": true, "internalType": "address", "name": "previousGovernor", "type": "address"},
-      {"indexed": true, "internalType": "address", "name": "proposedGovernor", "type": "address"}
-    ],
-    "name": "UpdatedGovernor",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {"indexed": true, "internalType": "address", "name": "strategy", "type": "address"},
-      {"indexed": false, "internalType": "uint256", "name": "interestFee", "type": "uint256"}
-    ],
-    "name": "UpdatedInterestFee",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {"indexed": true, "internalType": "address", "name": "strategy", "type": "address"},
-      {"indexed": false, "internalType": "uint256", "name": "debtRatio", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "debtRate", "type": "uint256"}
-    ],
-    "name": "UpdatedStrategyDebtParams",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {"indexed": false, "internalType": "uint256", "name": "previousWithdrawFee", "type": "uint256"},
-      {"indexed": false, "internalType": "uint256", "name": "newWithdrawFee", "type": "uint256"}
-    ],
-    "name": "UpdatedWithdrawFee",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
       {"indexed": true, "internalType": "address", "name": "owner", "type": "address"},
       {"indexed": false, "internalType": "uint256", "name": "shares", "type": "uint256"},
       {"indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256"}
@@ -149,46 +70,16 @@
   },
   {
     "inputs": [],
-    "name": "DOMAIN_SEPARATOR",
+    "name": "DOMAIN_TYPEHASH",
     "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
-    "name": "MAX_BPS",
-    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "name": "PERMIT_TYPEHASH",
+    "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "VERSION",
-    "outputs": [{"internalType": "string", "name": "", "type": "string"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {"inputs": [], "name": "acceptGovernorship", "outputs": [], "stateMutability": "nonpayable", "type": "function"},
-  {
-    "inputs": [
-      {"internalType": "address", "name": "_listToUpdate", "type": "address"},
-      {"internalType": "address", "name": "_addressToAdd", "type": "address"}
-    ],
-    "name": "addInList",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {"internalType": "address", "name": "_strategy", "type": "address"},
-      {"internalType": "uint256", "name": "_interestFee", "type": "uint256"},
-      {"internalType": "uint256", "name": "_debtRatio", "type": "uint256"},
-      {"internalType": "uint256", "name": "_debtRate", "type": "uint256"}
-    ],
-    "name": "addStrategy",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -211,13 +102,7 @@
     "stateMutability": "nonpayable",
     "type": "function"
   },
-  {
-    "inputs": [{"internalType": "address", "name": "_strategy", "type": "address"}],
-    "name": "availableCreditLimit",
-    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
+  {"inputs": [], "name": "approveToken", "outputs": [], "stateMutability": "nonpayable", "type": "function"},
   {
     "inputs": [{"internalType": "address", "name": "account", "type": "address"}],
     "name": "balanceOf",
@@ -226,8 +111,22 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "controller",
+    "outputs": [{"internalType": "contract IController", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [{"internalType": "uint256", "name": "_value", "type": "uint256"}],
     "name": "convertFrom18",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "_value", "type": "uint256"}],
+    "name": "convertTo18",
     "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
     "stateMutability": "pure",
     "type": "function"
@@ -250,7 +149,7 @@
     "type": "function"
   },
   {
-    "inputs": [{"internalType": "uint256", "name": "_amount", "type": "uint256"}],
+    "inputs": [{"internalType": "uint256", "name": "amount", "type": "uint256"}],
     "name": "deposit",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -258,11 +157,11 @@
   },
   {
     "inputs": [
-      {"internalType": "uint256", "name": "_amount", "type": "uint256"},
-      {"internalType": "uint256", "name": "_deadline", "type": "uint256"},
-      {"internalType": "uint8", "name": "_v", "type": "uint8"},
-      {"internalType": "bytes32", "name": "_r", "type": "bytes32"},
-      {"internalType": "bytes32", "name": "_s", "type": "bytes32"}
+      {"internalType": "uint256", "name": "amount", "type": "uint256"},
+      {"internalType": "uint256", "name": "deadline", "type": "uint256"},
+      {"internalType": "uint8", "name": "v", "type": "uint8"},
+      {"internalType": "bytes32", "name": "r", "type": "bytes32"},
+      {"internalType": "bytes32", "name": "s", "type": "bytes32"}
     ],
     "name": "depositWithPermit",
     "outputs": [],
@@ -270,9 +169,9 @@
     "type": "function"
   },
   {
-    "inputs": [{"internalType": "address", "name": "_strategy", "type": "address"}],
-    "name": "excessDebt",
-    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "inputs": [],
+    "name": "domainSeparator",
+    "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
     "stateMutability": "view",
     "type": "function"
   },
@@ -285,15 +184,15 @@
   },
   {
     "inputs": [],
-    "name": "feeWhitelist",
-    "outputs": [{"internalType": "contract IAddressList", "name": "", "type": "address"}],
+    "name": "feeWhiteList",
+    "outputs": [{"internalType": "contract IAddressListExt", "name": "", "type": "address"}],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [],
-    "name": "governor",
-    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "name": "getPricePerShare",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
     "stateMutability": "view",
     "type": "function"
   },
@@ -307,36 +206,8 @@
     "stateMutability": "nonpayable",
     "type": "function"
   },
-  {"inputs": [], "name": "init", "outputs": [], "stateMutability": "nonpayable", "type": "function"},
   {
-    "inputs": [],
-    "name": "keepers",
-    "outputs": [{"internalType": "contract IAddressList", "name": "", "type": "address"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "maintainers",
-    "outputs": [{"internalType": "contract IAddressList", "name": "", "type": "address"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {"internalType": "address", "name": "_old", "type": "address"},
-      {"internalType": "address", "name": "_new", "type": "address"}
-    ],
-    "name": "migrateStrategy",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {"internalType": "address[]", "name": "_recipients", "type": "address[]"},
-      {"internalType": "uint256[]", "name": "_amounts", "type": "uint256[]"}
-    ],
+    "inputs": [{"internalType": "uint256[]", "name": "bits", "type": "uint256[]"}],
     "name": "multiTransfer",
     "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
     "stateMutability": "nonpayable",
@@ -350,7 +221,7 @@
     "type": "function"
   },
   {
-    "inputs": [{"internalType": "address", "name": "owner", "type": "address"}],
+    "inputs": [{"internalType": "address", "name": "", "type": "address"}],
     "name": "nonces",
     "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
     "stateMutability": "view",
@@ -369,7 +240,7 @@
     "inputs": [
       {"internalType": "address", "name": "owner", "type": "address"},
       {"internalType": "address", "name": "spender", "type": "address"},
-      {"internalType": "uint256", "name": "value", "type": "uint256"},
+      {"internalType": "uint256", "name": "amount", "type": "uint256"},
       {"internalType": "uint256", "name": "deadline", "type": "uint256"},
       {"internalType": "uint8", "name": "v", "type": "uint8"},
       {"internalType": "bytes32", "name": "r", "type": "bytes32"},
@@ -380,46 +251,13 @@
     "stateMutability": "nonpayable",
     "type": "function"
   },
-  {
-    "inputs": [],
-    "name": "pricePerShare",
-    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {"internalType": "address", "name": "_listToUpdate", "type": "address"},
-      {"internalType": "address", "name": "_addressToRemove", "type": "address"}
-    ],
-    "name": "removeFromList",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {"internalType": "uint256", "name": "_profit", "type": "uint256"},
-      {"internalType": "uint256", "name": "_loss", "type": "uint256"},
-      {"internalType": "uint256", "name": "_payback", "type": "uint256"}
-    ],
-    "name": "reportEarning",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
+  {"inputs": [], "name": "rebalance", "outputs": [], "stateMutability": "nonpayable", "type": "function"},
+  {"inputs": [], "name": "resetApproval", "outputs": [], "stateMutability": "nonpayable", "type": "function"},
   {"inputs": [], "name": "shutdown", "outputs": [], "stateMutability": "nonpayable", "type": "function"},
   {
     "inputs": [],
     "name": "stopEverything",
     "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-    "name": "strategies",
-    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
     "stateMutability": "view",
     "type": "function"
   },
@@ -440,8 +278,8 @@
     "type": "function"
   },
   {
-    "inputs": [{"internalType": "address", "name": "_fromToken", "type": "address"}],
-    "name": "sweepERC20",
+    "inputs": [{"internalType": "address", "name": "_erc20", "type": "address"}],
+    "name": "sweepErc20",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -462,28 +300,14 @@
   },
   {
     "inputs": [],
+    "name": "tokenLocked",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "tokensHere",
-    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "totalDebt",
-    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{"internalType": "address", "name": "_strategy", "type": "address"}],
-    "name": "totalDebtOf",
-    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "totalDebtRatio",
     "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
     "stateMutability": "view",
     "type": "function"
@@ -523,75 +347,17 @@
     "stateMutability": "nonpayable",
     "type": "function"
   },
-  {
-    "inputs": [{"internalType": "address", "name": "_proposedGovernor", "type": "address"}],
-    "name": "transferGovernorship",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
   {"inputs": [], "name": "unpause", "outputs": [], "stateMutability": "nonpayable", "type": "function"},
   {
-    "inputs": [
-      {"internalType": "address", "name": "_strategy", "type": "address"},
-      {"internalType": "uint256", "name": "_debtRate", "type": "uint256"}
-    ],
-    "name": "updateDebtRate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {"internalType": "address", "name": "_strategy", "type": "address"},
-      {"internalType": "uint256", "name": "_debtRatio", "type": "uint256"}
-    ],
-    "name": "updateDebtRatio",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{"internalType": "address", "name": "_newFeeCollector", "type": "address"}],
-    "name": "updateFeeCollector",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {"internalType": "address", "name": "_strategy", "type": "address"},
-      {"internalType": "uint256", "name": "_interestFee", "type": "uint256"}
-    ],
-    "name": "updateInterestFee",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{"internalType": "uint256", "name": "_newWithdrawFee", "type": "uint256"}],
-    "name": "updateWithdrawFee",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{"internalType": "address[]", "name": "_withdrawQueue", "type": "address[]"}],
-    "name": "updateWithdrawQueue",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{"internalType": "uint256", "name": "_shares", "type": "uint256"}],
-    "name": "whitelistedWithdraw",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{"internalType": "uint256", "name": "_shares", "type": "uint256"}],
+    "inputs": [{"internalType": "uint256", "name": "shares", "type": "uint256"}],
     "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "shares", "type": "uint256"}],
+    "name": "withdrawByStrategy",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -600,13 +366,6 @@
     "inputs": [],
     "name": "withdrawFee",
     "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-    "name": "withdrawQueue",
-    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
     "stateMutability": "view",
     "type": "function"
   }

--- a/src/controller/.routes.yml
+++ b/src/controller/.routes.yml
@@ -149,6 +149,17 @@ splitRevenue:
     - http:
         path: /splitRevenue
         method: get
+        
+buybackVsp:
+  handler: src/controller/pool.buybackVsp
+  timeout: 900
+  events:
+    # TODO Buyback VSP using USDC asset, Similarly Need to add scheduler for other asset.
+    - schedule: 
+        rate: cron(10 13 * * ? *)
+        input:
+          asset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+          amount: 10000000000
 
 # feeTransfer:
 #   handler: src/controller/pool.feeTransfer

--- a/src/controller/pool.js
+++ b/src/controller/pool.js
@@ -9,6 +9,7 @@ const lowWater = require('../service/ops/lowWater')
 const rebalance = require('../service/ops/rebalance')
 const resurface = require('../service/ops/resurface')
 const splitRevenue = require('../service/ops/splitRevenue')
+const buybackVsp = require('../service/ops/buybackVsp')
 const claimComp = require('../service/ops/claimComp')
 const feeTransfer = require('../service/ops/feeTransfer')
 const accrueInterest = require('../service/ops/accrueInterest')
@@ -28,6 +29,7 @@ async function execute(input) {
     rebalance,
     resurface,
     splitRevenue,
+    buybackVsp,
     claimComp,
     feeTransfer,
     accrueInterest,
@@ -90,6 +92,14 @@ module.exports.lowWater = () => {
 
 module.exports.splitRevenue = () => {
   return execute({operation: Operation.SPLIT_REVENUE_ERC20})
+}
+
+module.exports.buybackVsp = event => {
+  return execute({
+    operation: Operation.BUYBACK_VSP,
+    asset: event.asset,
+    amount: event.amount,
+  })
 }
 
 module.exports.claimComp = () => {

--- a/src/enum/operation.js
+++ b/src/enum/operation.js
@@ -11,6 +11,7 @@ const Operation = {
   FEE_TRANSFER: 'feeTransfer',
   ACCRUE_INTEREST: 'accrueInterest',
   LOW_WATER: 'lowWater',
+  BUYBACK_VSP: 'buybackVsp',
 }
 
 module.exports = {

--- a/src/service/ops/buybackVsp.js
+++ b/src/service/ops/buybackVsp.js
@@ -1,0 +1,209 @@
+/* eslint-disable consistent-return */
+'use strict'
+
+const config = require('config')
+const ethers = require('ethers')
+const {getGasPrice, getWallet} = require('../../ethers/eth')
+const {getContractMetadata} = require('../../util/contract')
+const {getPriority} = require('../../enum/priority')
+const poolProxyAbi = require('../../abi/poolProxyImpl.json')
+const {Operation} = require('../../enum/operation')
+const {isRecentTransaction} = require('../recent')
+const revenueConfig = config.get('vesper.revenueConfig')
+const {send} = require('../transaction')
+const {getLogger} = require('../../util/logger')
+const buybackAbi = require('../../abi/buybackAbi.json')
+const vesperERC20TokenAbi = require('../../abi/ERC20Abi.json')
+const {BigNumber: BN} = require('ethers')
+const DECIMAL18 = BN.from('1000000000000000000')
+const operation = Operation.BUYBACK_VSP
+
+async function shouldSkipTheJob(data) {
+  if (data.batchTxns.length > 0) {
+    return isRecentTransaction(data)
+  }
+  return true
+}
+
+function run(data) {
+  const priority = config.vesper[data.operation] ? config.vesper[data.operation].priority : config.vesper.priority
+  return getGasPrice(data.blockingTxnGasPrice).then(function (gasPrice) {
+    const params = {
+      pool: data.name || data.pool,
+      fromAddress: data.fromAddress,
+      nonce: data.nonce,
+      priority: getPriority(priority),
+      gasPrice,
+      operation: data.operation,
+      toAddress: data.toAddress,
+      // `payeeAddress` Using existing DDB column.
+      payeeAddress: data.amount.toString(),
+      assetAddress: data.asset,
+      isBlockingTxn: !!data.blockingTxnGasPrice,
+    }
+    const methodArgs = [data.batchTxns, false]
+    return send(params, data.contract, 'batch', methodArgs)
+  })
+}
+
+function prepareJob(data, batchJobPromises) {
+  const batchTxns = []
+  return Promise.all(batchJobPromises).then(function (txns) {
+    for (const txn of txns) {
+      batchTxns.push(txn.data)
+    }
+    const jobs = []
+    jobs.push({
+      operationObj: module.exports,
+      toAddress: revenueConfig.buybackAddress,
+      operation: Operation.BUYBACK_VSP,
+      name: Operation.BUYBACK_VSP,
+      fromAddress: data.wallet.address,
+      asset: data.asset,
+      amount: data.amount,
+      contract: data.contract,
+      wallet: data.wallet,
+      batchTxns,
+    })
+    return jobs
+  })
+}
+
+function getPoolContract(vtoken, provider) {
+  return new ethers.Contract(vtoken, poolProxyAbi, provider)
+}
+
+function getBalanceAmountInCollateralToken(poolContract) {
+  const promises = []
+  promises.push(poolContract.balanceOf(revenueConfig.buybackAddress))
+  promises.push(poolContract.getPricePerShare())
+  promises.push(poolContract.withdrawFee())
+  return Promise.all(promises).then(function ([balance, pricePerShare, withdrawFee]) {
+    const withdrawFeeAmount = balance.mul(withdrawFee).div(DECIMAL18)
+    // all vTokens are 18 decimals
+    return balance.sub(withdrawFeeAmount).mul(pricePerShare).div(DECIMAL18)
+  })
+}
+
+function prepareVspBuyback(data, batchJobPromises) {
+  batchJobPromises.push(data.contract.populateTransaction.swapForVspAndTransferToVVSP(data.asset, data.amount))
+  return prepareJob(data, batchJobPromises)
+}
+
+function prepareUnwrapAndBuyback(data, batchJobPromises) {
+  return getContractMetadata([]).then(async function (pools) {
+    const poolPromises = []
+    pools.forEach(function (poolObj) {
+      poolPromises.push(getPoolContract(poolObj.contract.address, data.wallet.provider).token())
+    })
+    return Promise.all(poolPromises).then(function (tokens) {
+      const vTokenBalPromises = []
+      const matchedVToken = []
+      tokens.forEach(function (token, index) {
+        if (token === data.asset) {
+          const vTokenContract = new ethers.Contract(token, vesperERC20TokenAbi, data.wallet.provider)
+          matchedVToken.push(pools[index])
+          vTokenBalPromises.push(vTokenContract.balanceOf(revenueConfig.buybackAddress))
+        }
+      })
+
+      // Prepare mapping of vToken and it's balance.
+      const vTokenBalMapping = {}
+      return Promise.all(vTokenBalPromises).then(function (vTokenBalances) {
+        vTokenBalances.forEach(function (vTokenBalance, matchVTokenIndex) {
+          const key = matchedVToken[matchVTokenIndex].contract.address
+          vTokenBalMapping[key] = vTokenBalance
+        })
+
+        // sort vToken's balance in decreasing order
+        const vTokenBalMappingSorted = Object.fromEntries(Object.entries(vTokenBalMapping).sort((a, b) => b[1] - a[1]))
+        const vTokens = Object.keys(vTokenBalMappingSorted)
+
+        // Calculate vToken value in collateral token
+        const balancePromise = []
+        vTokens.forEach(function (vToken) {
+          const poolContract = getPoolContract(vToken, data.wallet.provider)
+          balancePromise.push(getBalanceAmountInCollateralToken(poolContract))
+        })
+
+        let availableBalance = data.buybackBalance
+        const requiredAmount = data.amount
+        let index = 0
+        return Promise.all(balancePromise).then(function (balances) {
+          // iterate and unwrap till we have enough collateral token balance for buyback
+          while (requiredAmount.gt(availableBalance) && index < balances.length) {
+            // prepare unwrap job
+            batchJobPromises.push(data.contract.populateTransaction.unwrapAll(vTokens[index]))
+            availableBalance = availableBalance.add(balances[index])
+            index++
+          }
+          // Buy VSP only if enough balance.
+          if (availableBalance.gte(requiredAmount)) {
+            return prepareVspBuyback(data, batchJobPromises)
+          }
+          const logger = getLogger()
+          logger.warn(
+            'Buyback asset: %s, available balance: %s, Required amount: %s, Not enough balance for buyback',
+            data.asset,
+            availableBalance,
+            requiredAmount
+          )
+          return prepareJob(data, [])
+        })
+      })
+    })
+  })
+}
+
+function prepare(data) {
+  data.amount = BN.from(data.amount)
+  if (data.amount.eq(0)) {
+    throw new Error('Amount should be greater than zero')
+  }
+  return getWallet().then(function (wallet) {
+    data.wallet = wallet
+    data.contract = new ethers.Contract(revenueConfig.buybackAddress, buybackAbi, wallet)
+    const collateralTokenContract = new ethers.Contract(data.asset, vesperERC20TokenAbi, wallet.provider)
+    return collateralTokenContract.balanceOf(revenueConfig.buybackAddress).then(function (buybackBalance) {
+      data.buybackBalance = buybackBalance
+      const batchJobPromises = []
+      if (data.buybackBalance.lt(data.amount)) {
+        // Need to unwrap and then buyback
+        return prepareUnwrapAndBuyback(data, batchJobPromises)
+      }
+      // unwrap not needed, just add buyback job
+      return prepareVspBuyback(data, batchJobPromises)
+    })
+  })
+}
+
+async function before(data) {
+  return require('./pool').before(data)
+}
+
+async function after(data) {
+  return require('./pool').after(data)
+}
+
+async function error(data, _error) {
+  return require('./pool').error(data, _error)
+}
+
+async function executeJob(_data) {
+  return before(_data).then(function (data) {
+    return run(data)
+      .then(function () {
+        return after(data)
+      })
+      .catch(function (_error) {
+        return error(data, _error)
+      })
+  })
+}
+
+module.exports = {
+  prepare,
+  executeJob,
+  shouldSkipTheJob,
+  operation,
+}

--- a/src/service/ops/pool.js
+++ b/src/service/ops/pool.js
@@ -5,6 +5,7 @@ const rebalanceCollateral = require('./rebalanceCollateral')
 const rebalance = require('./rebalance')
 const resurface = require('./resurface')
 const splitRevenue = require('./splitRevenue')
+const buybackVsp = require('./buybackVsp')
 const lowWater = require('./lowWater')
 const updateOracles = require('./updateOracles')
 const claimComp = require('../../service/ops/claimComp')
@@ -40,6 +41,7 @@ function getOperationObject(data) {
     rebalance,
     resurface,
     splitRevenue,
+    buybackVsp,
     updateOracles,
     claimComp,
     lowWater,


### PR DESCRIPTION
 The fix include

- Buyback VSP using vToken.
- The buyback function takes input as collateral token and amount.
- if enough collateral token amount already exits on buyback contract, it simply calls batch operation with just buyback txn.
- if not, then it first unwraps vTokens which has max available balance, and then calls buyback. This can have 2 or more txns in a batch.
